### PR TITLE
Add decoder function.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "decoder/axioma-qalcosonic-w1"]
+	path = decoder/axioma-qalcosonic-w1
+	url = git@github.com:anypayload/axioma-qalcosonic-w1.git

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ A quick look at the top-level files and directories you'll see in a Gatsby proje
     ├── package-lock.json
     ├── package.json
     └── README.md
+    └── decoder
+    └── netlify/functions
 
 1.  **`/node_modules`**: This directory contains all of the modules of code that your project depends on (npm packages) are automatically installed.
 
@@ -63,6 +65,10 @@ A quick look at the top-level files and directories you'll see in a Gatsby proje
 11. **`package.json`**: A manifest file for Node.js projects, which includes things like metadata (the project’s name, author, etc). This manifest is how npm knows which packages to install for your project.
 
 12. **`README.md`**: A text file containing useful reference information about your project.
+
+13. **`decoder`**: Contains Git submodules of the decoder provided via functions.
+
+14. **`netlify/functions`**: Contains Netlify functions for the decoders.
 
 ## 🎓 Learning Gatsby
 

--- a/netlify/functions/decoder.mjs
+++ b/netlify/functions/decoder.mjs
@@ -17,14 +17,13 @@ export default async (req, context) => {
 
     console.log(`received payload '${payload}' for device '${device}' on port '${port}'`);
 
-    const bytes = hexToBytes(payload);
+    const bytes = Buffer.from(payload, 'hex');
 
     console.log('decoded bytes:', bytes);
-    console.log('decoded bytes via Buffer:', Buffer.from(payload, 'hex'));
 
     switch (device) {
         case "axioma-qalcosonic-w1":
-            const decoded = Decode(bytes, port);
+            const decoded = Decode(port, bytes);
             console.log('decoded:', decoded);
             return Response.json(decoded, { status: 200 });
         default:

--- a/netlify/functions/decoder.mjs
+++ b/netlify/functions/decoder.mjs
@@ -1,5 +1,4 @@
-import doDecode from '../../decoder/axioma-qalcosonic-w1/javascript/decoder.js';
-import hexToBytes from '../../decoder/axioma-qalcosonic-w1/javascript/decoder.js';
+import '../../decoder/axioma-qalcosonic-w1/javascript/decoder.js';
 
 export default async (req, context) => {
     switch (context.params.device) {

--- a/netlify/functions/decoder.mjs
+++ b/netlify/functions/decoder.mjs
@@ -1,4 +1,4 @@
-const Decode = require("../../decoder/axioma-qalcosonic-w1/javascript/decoder.js");
+const { Decode: decodeAxiomaQalW1 } = require("../../decoder/axioma-qalcosonic-w1/javascript/decoder.js");
 
 // Convert a hex string to a byte array
 function hexToBytes(hex) {
@@ -19,11 +19,9 @@ export default async (req, context) => {
 
     const bytes = Buffer.from(payload, 'hex');
 
-    console.log('decoded bytes:', bytes);
-
     switch (device) {
         case "axioma-qalcosonic-w1":
-            const decoded = Decode(port, bytes);
+            const decoded = decodeAxiomaQalW1(port, bytes);
             console.log('decoded:', decoded);
             return Response.json(decoded, { status: 200 });
         default:

--- a/netlify/functions/decoder.mjs
+++ b/netlify/functions/decoder.mjs
@@ -1,15 +1,21 @@
-import '../../decoder/axioma-qalcosonic-w1/javascript/decoder.js';
+const Decode = require("../../decoder/axioma-qalcosonic-w1/javascript/decoder.js");
 
 export default async (req, context) => {
-    console.log("payload", req.body.payload)
-    switch (context.params.device) {
+    const payload = req.body.payload;
+    const device = context.params.device;
+    const port = req.body.port;
+
+    console.log(`received payload '${payload}' for device '${device}' on port '${port}'`);
+
+    const bytes = Buffer.from(payload, "hex");
+
+    switch (device) {
         case "axioma-qalcosonic-w1":
-            const payload = hexToBytes(req.body.payload);
-            const port = req.body.port;
-            decoded = doDecode(payload, port);
+            const decoded = Decode(bytes, port);
             return Response.json(decoded, { status: 200 });
         default:
-            return new Response("Unknown decoder", { status: 404 });
+            console.error(`no decoder found for device '${device}'`);
+            return Response.json({error: "Unknown decoder"}, { status: 404 });
     }
 };
 

--- a/netlify/functions/decoder.mjs
+++ b/netlify/functions/decoder.mjs
@@ -1,13 +1,3 @@
-const { Decode: decodeAxiomaQalW1 } = require("../../decoder/axioma-qalcosonic-w1/javascript/decoder.js");
-
-// Convert a hex string to a byte array
-function hexToBytes(hex) {
-    let bytes = [];
-    for (let c = 0; c < hex.length; c += 2)
-        bytes.push(parseInt(hex.substr(c, 2), 16));
-    return bytes;
-}
-
 export default async (req, context) => {
     const { device } = context.params;
 
@@ -21,7 +11,8 @@ export default async (req, context) => {
 
     switch (device) {
         case "axioma-qalcosonic-w1":
-            const decoded = decodeAxiomaQalW1(port, bytes);
+            const Decode = require("../../decoder/axioma-qalcosonic-w1/javascript/decoder.js");
+            const decoded = Decode(port, bytes);
             console.log('decoded:', decoded);
             return Response.json(decoded, { status: 200 });
         default:

--- a/netlify/functions/decoder.mjs
+++ b/netlify/functions/decoder.mjs
@@ -1,14 +1,22 @@
 import '../../decoder/axioma-qalcosonic-w1/javascript/decoder.js';
 
-export default async (req, context) => {
+exports.handler = async function(event, context) {
     switch (context.params.device) {
         case "axioma-qalcosonic-w1":
-            const payload = hexToBytes(req.body.payload);
-            const port = req.body.port;
+            const payload = hexToBytes(event.body.payload);
+            const port = event.body.port;
             decoded = doDecode(payload, port);
-            return Response.json(decoded, { status: 200 });
+            return {
+                statusCode: 200,
+                body: JSON.stringify(decoded)
+            };
         default:
-            return Response("Unknown decoder", { status: 404 });
+            return {
+                statusCode: 404,
+                body: JSON.stringify({
+                    error: "Device not found"
+                })
+            }
     }
 };
 

--- a/netlify/functions/decoder.mjs
+++ b/netlify/functions/decoder.mjs
@@ -6,7 +6,7 @@ export default async (req, context) => {
             const payload = hexToBytes(req.body.payload);
             const port = req.body.port;
             decoded = decodeAxiomaQalcosonicW1(payload, port);
-            return new Response(decoded, { status: 200 });
+            return new Response.json(decoded, { status: 200 });
         default:
             return new Response("Unknown decoder", { status: 404 });
     }

--- a/netlify/functions/decoder.mjs
+++ b/netlify/functions/decoder.mjs
@@ -1,22 +1,15 @@
 import '../../decoder/axioma-qalcosonic-w1/javascript/decoder.js';
 
-exports.handler = async function(event, context) {
+export default async (req, context) => {
+    console.log("payload", req.body.payload)
     switch (context.params.device) {
         case "axioma-qalcosonic-w1":
-            const payload = hexToBytes(event.body.payload);
-            const port = event.body.port;
+            const payload = hexToBytes(req.body.payload);
+            const port = req.body.port;
             decoded = doDecode(payload, port);
-            return {
-                statusCode: 200,
-                body: JSON.stringify(decoded)
-            };
+            return Response.json(decoded, { status: 200 });
         default:
-            return {
-                statusCode: 404,
-                body: JSON.stringify({
-                    error: "Device not found"
-                })
-            }
+            return new Response("Unknown decoder", { status: 404 });
     }
 };
 

--- a/netlify/functions/decoder.mjs
+++ b/netlify/functions/decoder.mjs
@@ -1,0 +1,14 @@
+import { doDecode as decodeAxiomaQalcosonicW1 } from '../../decoder/axioma-qalcosonic-w1/javascript/decoder.js';
+
+export default async (req, context) => {
+    switch (context.params.device) {
+        case "axioma-qalcosonic-w1":
+            return new Response(decodeAxiomaQalcosonicW1(req.body.bytes, req.body.fPort));
+        default:
+            return new Response("Unknown decoder", { status: 404 });
+    }
+};
+
+export const config = {
+    path: "/decoders/:device"
+};

--- a/netlify/functions/decoder.mjs
+++ b/netlify/functions/decoder.mjs
@@ -1,9 +1,12 @@
-import { doDecode as decodeAxiomaQalcosonicW1 } from '../../decoder/axioma-qalcosonic-w1/javascript/decoder.js';
+import { doDecode as decodeAxiomaQalcosonicW1, hexToBytes } from '../../decoder/axioma-qalcosonic-w1/javascript/decoder.js';
 
 export default async (req, context) => {
     switch (context.params.device) {
         case "axioma-qalcosonic-w1":
-            return new Response(decodeAxiomaQalcosonicW1(req.body.bytes, req.body.fPort));
+            const payload = hexToBytes(req.body.payload);
+            const port = req.body.port;
+            decoded = decodeAxiomaQalcosonicW1(payload, port);
+            return new Response(decoded, { status: 200 });
         default:
             return new Response("Unknown decoder", { status: 404 });
     }

--- a/netlify/functions/decoder.mjs
+++ b/netlify/functions/decoder.mjs
@@ -1,11 +1,12 @@
-import { doDecode as decodeAxiomaQalcosonicW1, hexToBytes } from '../../decoder/axioma-qalcosonic-w1/javascript/decoder.js';
+import doDecode from '../../decoder/axioma-qalcosonic-w1/javascript/decoder.js';
+import hexToBytes from '../../decoder/axioma-qalcosonic-w1/javascript/decoder.js';
 
 export default async (req, context) => {
     switch (context.params.device) {
         case "axioma-qalcosonic-w1":
             const payload = hexToBytes(req.body.payload);
             const port = req.body.port;
-            decoded = decodeAxiomaQalcosonicW1(payload, port);
+            decoded = doDecode(payload, port);
             return new Response.json(decoded, { status: 200 });
         default:
             return new Response("Unknown decoder", { status: 404 });

--- a/netlify/functions/decoder.mjs
+++ b/netlify/functions/decoder.mjs
@@ -1,5 +1,13 @@
 const Decode = require("../../decoder/axioma-qalcosonic-w1/javascript/decoder.js");
 
+// Convert a hex string to a byte array
+function hexToBytes(hex) {
+    let bytes = [];
+    for (let c = 0; c < hex.length; c += 2)
+        bytes.push(parseInt(hex.substr(c, 2), 16));
+    return bytes;
+}
+
 export default async (req, context) => {
     const { device } = context.params;
 
@@ -9,11 +17,15 @@ export default async (req, context) => {
 
     console.log(`received payload '${payload}' for device '${device}' on port '${port}'`);
 
-    const bytes = Buffer.from(payload, "hex");
+    const bytes = hexToBytes(payload);
+
+    console.log('decoded bytes:', bytes);
+    console.log('decoded bytes via Buffer:', Buffer.from(payload, 'hex'));
 
     switch (device) {
         case "axioma-qalcosonic-w1":
             const decoded = Decode(bytes, port);
+            console.log('decoded:', decoded);
             return Response.json(decoded, { status: 200 });
         default:
             console.error(`no decoder found for device '${device}'`);

--- a/netlify/functions/decoder.mjs
+++ b/netlify/functions/decoder.mjs
@@ -6,9 +6,9 @@ export default async (req, context) => {
             const payload = hexToBytes(req.body.payload);
             const port = req.body.port;
             decoded = doDecode(payload, port);
-            return new Response.json(decoded, { status: 200 });
+            return Response.json(decoded, { status: 200 });
         default:
-            return new Response("Unknown decoder", { status: 404 });
+            return Response("Unknown decoder", { status: 404 });
     }
 };
 

--- a/netlify/functions/decoder.mjs
+++ b/netlify/functions/decoder.mjs
@@ -1,9 +1,11 @@
 const Decode = require("../../decoder/axioma-qalcosonic-w1/javascript/decoder.js");
 
 export default async (req, context) => {
-    const payload = req.body.payload;
-    const device = context.params.device;
-    const port = req.body.port;
+    const { device } = context.params;
+
+    const body = await req.json()
+    const payload = body.payload;
+    const port = body.port;
 
     console.log(`received payload '${payload}' for device '${device}' on port '${port}'`);
 

--- a/src/pages/products.js
+++ b/src/pages/products.js
@@ -26,7 +26,8 @@ const DECODERS = {
   },
   'axioma-qalcosonic-w1': {
     name: 'Axioma W1 Ultrasonic Water Meter',
-    payload: '0x38CC4666100000000040F5456600000000000000000000000000000000000000000000000000000000000000000000',
+    payload: '0x199B4262304E8B050060BF4162EAF20400C400C109C409C409a4098809C409C509C409C409C409C409C809C009C409',
+    port: 100,
     api: '/decoders/axioma-qalcosonic-w1'
   },
   'bosch-parking-lot-sensor': {

--- a/src/pages/products.js
+++ b/src/pages/products.js
@@ -27,7 +27,7 @@ const DECODERS = {
   'axioma-qalcosonic-w1': {
     name: 'Axioma W1 Ultrasonic Water Meter',
     payload: '0x38CC4666100000000040F5456600000000000000000000000000000000000000000000000000000000000000000000',
-    api: 'decoders/axioma-qalcosonic-w1'
+    api: '/decoders/axioma-qalcosonic-w1'
   },
   'bosch-parking-lot-sensor': {
     name: 'Bosch Parking Lot Sensor',

--- a/src/pages/products.js
+++ b/src/pages/products.js
@@ -24,6 +24,11 @@ const DECODERS = {
     name: 'Adeunis Field Test Device',
     payload: '0xBF1B45159690005534502720200FC95207',
   },
+  'axioma-qalcosonic-w1': {
+    name: 'Axioma W1 Ultrasonic Water Meter',
+    payload: '0x38CC4666100000000040F5456600000000000000000000000000000000000000000000000000000000000000000000',
+    api: 'decoders/axioma-qalcosonic-w1'
+  },
   'bosch-parking-lot-sensor': {
     name: 'Bosch Parking Lot Sensor',
     payload: '0x00FE',
@@ -140,6 +145,7 @@ class Decoder extends React.Component {
       decoder: "elsys",
       payload: "",
       port: null,
+      api: null,
       decoded: null,
       loading: false
     }
@@ -175,6 +181,7 @@ class Decoder extends React.Component {
     // Remove optional hex prefix
     const payload = this.state.payload.replace('0x', '')
     const port = parseInt(this.state.port)
+    const api = this.state.api || `${DECODER_API}/decoders/${decoder}`
 
     console.info(`Decode payload '${payload}' using '${decoder}'`)
 
@@ -184,7 +191,9 @@ class Decoder extends React.Component {
       body: JSON.stringify({ payload: payload, port: port })
     }
 
-    fetch(`${DECODER_API}/decoders/${decoder}`, requestOptions)
+
+
+    fetch(api, requestOptions)
       .then(response => response.json())
       .then(data => this.setState({ decoded: data, loading: false }))
       .catch(error => this.setState({ loading: false }))

--- a/src/pages/products.js
+++ b/src/pages/products.js
@@ -162,7 +162,8 @@ class Decoder extends React.Component {
     if (name === 'decoder') {
       var decoder = DECODERS[value]
       this.setState({
-        port: decoder.port
+        port: decoder.port,
+        api: decoder.api
       })
     }
 


### PR DESCRIPTION
This PR provides JS decoders as Netlify functions.

New decoders have to be added as Git submodules in the decoder directory. Furthermore, the file decoder.mjs has to be extended referencing the folder of the added Git submodule.
An example has been provided via this PR for the Axioma Qalcosonic W1 decoder. This also extends the frontend to expose the new decoder.

For a preview, see also: https://deploy-preview-4--anypayload.netlify.app/products/

